### PR TITLE
Fix add-on build process so that it is recompiled after Python files are changed

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -50,7 +50,7 @@ addon_info = {
 # pythonSources = ["addon/globalPlugins/*.py"]
 # For more information on SCons Glob expressions please take a look at:
 # https://scons.org/doc/production/HTML/scons-user/apd.html
-pythonSources = ["addon/globalPlugins/*.py"]
+pythonSources = ["addon/globalPlugins/*/*.py"]
 
 # Files that contain strings for translation. Usually your python sources
 i18nSources = pythonSources + ["buildVars.py"]


### PR DESCRIPTION
The list of Python files didn't include add-on Python files - the SCons glob expressions do not recurse into sub-directories by default.