### PR TITLE
Use proper directory path when restarting versions of NVDA where globalVars.appDir is not defined

### DIFF
--- a/addon/globalPlugins/ndtt/compa.py
+++ b/addon/globalPlugins/ndtt/compa.py
@@ -10,20 +10,6 @@ import sys
 import controlTypes
 import globalVars
 
-try:
-# NVDA 2020.4+
-	from globalVars import appDir
-except ImportError:
-# NVDA <= 2020.3
-	if getattr(sys, "frozen", None):
-		# We are running as an executable.
-		appDir = sys.prefix
-	else:
-		# we are running from source
-		# We should always change directory to the location of an NVDA root module (e.g. globalVars), don't rely on sys.path[0]
-		appDir = os.path.normpath(os.path.dirname(globalVars.__file__))
-	appDir = os.path.abspath(appDir)
-
 
 # Following code based on Lukasz Golonka's work.
 
@@ -76,4 +62,20 @@ class ControlTypesCompatWrapper(object):
 	def __getattr__(self, attr):
 		return getattr(controlTypes, attr)
 
+
+def getApDir():
+	try:
+		# NVDA 2020.4+
+		return globalVars.appDir
+	except AttributeError:
+		# NVDA <= 2020.3
+		if getattr(sys, "frozen", None):
+			# We are running as an executable.
+			return sys.prefix  # No normalization necessary
+		# we are running from source
+		# Since we cannot rely on CWD being correct create a path from one of NVDA's core modules.
+		return os.path.abspath(os.path.normpath(os.path.dirname(globalVars.__file__)))
+
+
+appDir = getApDir()
 controlTypesCompatWrapper = ControlTypesCompatWrapper()

--- a/addon/globalPlugins/ndtt/restartWithOptions.py
+++ b/addon/globalPlugins/ndtt/restartWithOptions.py
@@ -7,7 +7,6 @@ from __future__ import unicode_literals
 
 import gui
 import queueHandler
-import core
 import globalVars
 import globalPluginHandler
 import addonHandler
@@ -18,25 +17,10 @@ import wx
 import sys
 import os
 import weakref
-from types import MethodType
+from . import compa
 
 ADDON_SUMMARY = addonHandler.getCodeAddon ().manifest["summary"]
 
-def initializeAppDir():
-	if getattr(sys, "frozen", None):
-		# We are running as an executable.
-		appDir = sys.prefix
-	else:
-		# we are running from source
-		# We should always change directory to the location of an NVDA root module (e.g. globalVars), don't rely on sys.path[0]
-		appDir = os.path.normpath(os.path.dirname(globalVars.__file__))
-	appDir = os.path.abspath(appDir)
-	return appDir
-
-try:
-	globalVars.appDir
-except AttributeError:
-	globalVars.appDir = initializeAppDir
 
 def restartWithOptions(options):
 	"""Restarts NVDA by starting a new copy, providing some options."""
@@ -58,11 +42,10 @@ def restartWithOptions(options):
 		options.append("-r")
 	file = sys.executable
 	parameters = subprocess.list2cmdline(options)
-	directory = globalVars.appDir
+	directory = compa.appDir
 	if sys.version_info.major < 3:
 		file = file.decode("mbcs")
 		parameters = parameters.decode("mbcs")
-		directory = None  # Set directory to None as per NVDA 2019.2.1's code; specifying the directory seems to cause issue.
 	shellapi.ShellExecute(
 		hwnd=None,
 		operation=None,


### PR DESCRIPTION
For versions of NVDA where `globalVars.appDir` is not defined you have created a function in the `restartWithOptions` which was retrieving proper directory path. Unfortunately when assigning its value to `globalVars.appDir` brackets were omitted causing the function rather than its return value to be assigned. Due to this you had to set directory to `None` when restarting older versions of NVDA,  also code which was supposed to provide `appDir` in the `compa` module never executed since `globalVars.appDir` always existed, but with a wrong value. This PR removes the duplicated (almost the same code existed in `compa`) function from the restart with options dialog and no longer touches value of `globalVars.appDir` rather the variable from `compa` is used. I've verified that NVDA 2019.2 restarts fine with these changes.