### PR TITLE
Enhanced exit dialog can now be opened after closing without restarting nVDA

### DIFF
--- a/addon/globalPlugins/ndtt/restartWithOptions.py
+++ b/addon/globalPlugins/ndtt/restartWithOptions.py
@@ -115,7 +115,6 @@ class CommandLineOption(object):
 		self.description = description
 		self.flagList = flagList
 		self.allowInSecureMode = allowInSecureMode
-		self.controls = []
 
 	def shouldBeDisabled(self):
 		return globalVars.appArgs.secure and not self.allowInSecureMode
@@ -159,7 +158,7 @@ class CommandLineBooleanOption(CommandLineOption):
 		)
 		checkBox.SetValue(False)
 		sHelper.addItem(checkBox)
-		self.controls.append(checkBox)
+		self.controls = (checkBox,)
 
 	def makeFlagValueString(self):
 		if self.value:
@@ -172,9 +171,6 @@ class CommandLineStringOption(CommandLineOption):
 	"""A command line option with an associated parameter, i.e. a flag with a value.
 	E.g. --lang=en
 	"""
-
-	def __init__(self, *args, **kw):
-		super(CommandLineStringOption, self).__init__(*args, **kw)
 
 	def makeFlagValueString(self):
 		val = self.value
@@ -200,7 +196,7 @@ class CommandLineChoiceOption(CommandLineStringOption):
 			choices=self.choices,
 		)
 		choice.SetSelection(0)
-		self.controls.append(choice)
+		self.controls = (choice,)
 
 	@property
 	def value(self):
@@ -245,8 +241,7 @@ class CommandLineFileOption(CommandLineStringOption):
 
 		fileEdit = fileEntryControl.pathControl
 		fileEdit.Value = ""
-		self.controls.append(fileEdit)
-		self.controls.append(fileEntryControl._browseButton)
+		self.controls = (fileEdit, fileEntryControl._browseButton)
 
 
 class CommandLineFolderOption(CommandLineStringOption):
@@ -267,8 +262,7 @@ class CommandLineFolderOption(CommandLineStringOption):
 		directoryEntryControl = groupHelper.addItem(directoryPathHelper)
 		directoryEdit = directoryEntryControl.pathControl
 		directoryEdit.Value = ""
-		self.controls.append(directoryEdit)
-		self.controls.append(directoryEntryControl._browseButton)
+		self.controls = (directoryEdit, directoryEntryControl._browseButton)
 
 
 class RestartWithOptionsDialog(gui.settingsDialogs.SettingsDialog):


### PR DESCRIPTION
To reproduce original problem:
- Open enhanced exit dialog with NVDA+Shift+q
- Close it by pressing ESC
- Try to  open it again by pressing NVDA+Shift+Q

The following is in the log, and the dialog fails to be populated:
```
ERROR - unhandled exception (16:34:34.651) - MainThread (7108):
Traceback (most recent call last):
  File "wx\core.pyc", line 3407, in <lambda>
  File "C:\Users\Lukasz\AppData\Roaming\nvda\addons\nvdaDevTestToolbox\globalPlugins\ndtt\restartWithOptions.py", line 423, in openRestartWithOptionsDialog
    d = RestartWithOptionsDialog(gui.mainFrame)
  File "C:\Users\Lukasz\AppData\Roaming\nvda\addons\nvdaDevTestToolbox\globalPlugins\ndtt\restartWithOptions.py", line 294, in __init__
    super(RestartWithOptionsDialog, self).__init__(parent)
  File "gui\settingsDialogs.pyc", line 217, in __init__
  File "C:\Users\Lukasz\AppData\Roaming\nvda\addons\nvdaDevTestToolbox\globalPlugins\ndtt\restartWithOptions.py", line 389, in postInit
    if o.mainControl.IsEnabled():
RuntimeError: wrapped C/C++ object of type CheckBox has been deleted


```

This occurs because GUI controls for each of the options are stored on the options instance, and it is created just once as a class variable. To fix this I have modified the code, so that GUI controls for each of these options are created fresh just before being added to the dialog.